### PR TITLE
Dockerfile improvements and FORCE_HTTPS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 # Create dirs and move files
 RUN mkdir -p /var/www
 WORKDIR /var/www
-COPY --chown=www-data:www-data . .
+COPY --chown=www-data:www-data package.json package-lock.json composer.json composer.lock artisan phpunit.xml config.json webpack.config.js webpack.mix.js .
 
 COPY .env.docker .env
 
@@ -39,9 +39,7 @@ RUN \
         --no-scripts \
         --prefer-dist \
     && echo "Installing Node dependencies...\n" \
-    && npm install \
-    && echo "Running migrations...\n" \
-    && npm run production
+    && npm install
 
 # Configure Apache
 COPY 000-default.conf /etc/apache2/sites-available/000-default.conf
@@ -59,6 +57,10 @@ RUN CRONFILE=/etc/cron.d/scheduler && \
 RUN mkdir -p /var/www/storage && \
     touch /var/www/storage/db.sqlite && \
     chown www-data:www-data /var/www/storage/db.sqlite
+
+COPY --chown=www-data:www-data . .
+
+RUN echo "Running migrations...\n" && npm run production
 
 # Run
 VOLUME [ "/games", "/var/www/storage" ]

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -23,6 +23,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        if (config('app.force_https')) {
+		\URL::forceScheme('https');
+        }
     }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -28,6 +28,8 @@ return [
 
     'env' => env('APP_ENV', 'production'),
 
+    'force_https' => env('FORCE_HTTPS', false),
+
     /*
     |--------------------------------------------------------------------------
     | Application Debug Mode

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+mkdir -p \
+  /var/www/storage/framework/views \
+  /var/www/storage/framework/testing \
+  /var/www/storage/framework/sessions \
+  /var/www/storage/framework/cache/data \
+  /var/www/storage/app/public \
+  /var/www/storage/logs
+
+touch /var/www/storage/db.sqlite
+chown -R 33:33 /var/www/storage
+
 php artisan cartridge:init
 
 echo "✈ Starting server..."


### PR DESCRIPTION
Hello!

 I've split the Dockerfile dependency install step out so that PHP changes can be made and the base layers (which are very large compared to the code layer) can be reused.

  I've also added the directory structure precreate script into the docker entrypoint so that, when using a Volume, the container "just works", and the subdirectory structure is automatically created on whatever disk is mounted at the volume.